### PR TITLE
Change condition for a letter to be marked as "wrong-position"

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -258,8 +258,8 @@ const App = () => {
                 // There is at least one of this letter that:
                 // 1) will not be revealed as correct and
                 // 2) hasn't been marked as in the wrong position yet
-                ([...Word].filter((x, index) => guess[index] === x && x === letter).length + // 1)
-                 [...guess.substring(0, column)].filter(x => x === letter).length) < numSameLetters // 2)
+                ([...Word].filter((x, index) => (guess[index] === x && x === letter) || //1)
+                    (index < column && guess[index] === letter)).length) < numSameLetters //2)
             ) {
                 hints[column] = "wrong_position";
                 setHintKeyMap(keyMap => {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -255,8 +255,11 @@ const App = () => {
                     return copy;
                 });
             } else if (Word.includes(letter) &&
-                [...guess.substring(0, column)].filter(x => x === letter).length < numSameLetters && // No information revealed about letter so far
-                [...Word].filter((x, index) => guess[index] === x && x === letter).length < numSameLetters // Letter not revealed in further hints
+                // There is at least one of this letter that:
+                // 1) will not be revealed as correct and
+                // 2) hasn't been marked as in the wrong position yet
+                ([...Word].filter((x, index) => guess[index] === x && x === letter).length + // 1)
+                 [...guess.substring(0, column)].filter(x => x === letter).length) < numSameLetters // 2)
             ) {
                 hints[column] = "wrong_position";
                 setHintKeyMap(keyMap => {


### PR DESCRIPTION
The **sum** of letters that are guessed correctly (green letters) and that have been marked as in the wrong position (yellow letters) has to be less than `numSameLetters`.
Before, we checked these conditions separately, which resulted in the following bug:
- let's say there are **2** Ts in today's word -> `numSameLetters = 2`
- we enter a word with **3** Ts, such that one of them is in the correct position
- we mark the correctly positioned T green
- we mark one of the other Ts yellow
- number of yellow Ts is < numSameLetters = 2 AND number of green Ts < numSameLetters = 2
- we mark the third T as in the wrong position, resulting in 3 Ts being marked as being in the word, when there are in fact only two.