### PR TITLE
Fix statistics modal

### DIFF
--- a/src/components/StatisticsModal.js
+++ b/src/components/StatisticsModal.js
@@ -37,7 +37,7 @@ const GuessDistributionGraph = ({data}) => {
     return (
         <div className="guess-distribution-graph-wrapper">
             {distribution.map((x, index) => {
-                const width = parseFloat(x) * 100.0 / parseFloat(largest);
+                const width = x * 100.0 / largest;
                 return (
                     <div key={index} className="guess-distribution-graph-element">
                         <div className="guess-distribution-graph-number">

--- a/src/components/StatisticsModal.js
+++ b/src/components/StatisticsModal.js
@@ -81,6 +81,8 @@ export default function StatisticsModal(props) {
     data.games.reverse().find(game => {
         if (game.solved) {
             currentStreak++;
+        } else if (!game.completed && datesAreOnSameDay(new Date(game.firstOpened), GameDate)) {
+            return false; //ignore today's game if it is unfinished and continue search
         } else {
             return true;
         }

--- a/src/components/StatisticsModal.js
+++ b/src/components/StatisticsModal.js
@@ -65,7 +65,7 @@ export default function StatisticsModal(props) {
     const completedTotal = data.games.filter(game => game.completed).length;
     const solvedTotal = data.games.filter(game => game.solved).length;
     const winPercentage = completedTotal ? Math.round(100.0 * solvedTotal / completedTotal) : 0;
-    const longestStreak = data.games.reduce((prev, curr, index, arr) => {
+    const longestStreak = data.games.reduce((prev, curr) => {
         if (curr.solved)
             return prev + 1;
         else return 0;
@@ -110,11 +110,11 @@ export default function StatisticsModal(props) {
                                 }
                             }).join('')).join('\n')
                         const caption = `Žodžiuks ${todaysGame.hints.length}/${Rows}`;
-                        const link = "https://zodziuks.lt";
+                        const link = "https://martynasd123.github.io/zodziuks/";
                         if (window.navigator.share) {
                             window.navigator
                                 .share({
-                                    text: caption + "\n" + hintMap + "\nhttps://zodziuks.lt",
+                                    text: caption + "\n" + hintMap + "\n" + link,
                                     // text: caption + "\n" + hintMap,
                                     // url: "https://zodziuks.lt",
                                 }).finally(() => {

--- a/src/components/StatisticsModal.js
+++ b/src/components/StatisticsModal.js
@@ -121,8 +121,9 @@ export default function StatisticsModal(props) {
                                     recordEvent(EVENT_TYPE.SHARED);
                             })
                         } else {
-                            setToast("Nukopijuota į iškarpinę")
-                            window.navigator.clipboard.writeText(caption + "\n" + hintMap + "\n" + link);
+                            window.navigator.clipboard.writeText(caption + "\n" + hintMap + "\n" + link)
+                                .then(() => setToast("Nukopijuota į iškarpinę"))
+                                .catch(() => setToast("Klaida - kopijavimas \n į iškarpinę neleidžiamas"))
                             recordEvent(EVENT_TYPE.SHARED_CLIPBOARD);
                         }
                     }

--- a/src/components/StatisticsModal.js
+++ b/src/components/StatisticsModal.js
@@ -65,20 +65,27 @@ export default function StatisticsModal(props) {
     const completedTotal = data.games.filter(game => game.completed).length;
     const solvedTotal = data.games.filter(game => game.solved).length;
     const winPercentage = completedTotal ? Math.round(100.0 * solvedTotal / completedTotal) : 0;
-    const longestStreak = data.games.reduce((prev, curr) => {
+
+    let longestStreak = 0;
+    let firstStreak = data.games.reduce((prev, curr) => {
         if (curr.solved)
             return prev + 1;
-        else return 0;
+        else {
+            longestStreak = Math.max(longestStreak, prev);
+            return 0
+        }
     }, 0);
+    longestStreak = Math.max(longestStreak, firstStreak);
+
     let currentStreak = 0;
     data.games.reverse().find(game => {
         if (game.solved) {
             currentStreak++;
-        } else if (game.completed) {
-            currentStreak = 0;
+        } else {
             return true;
         }
     });
+
     const todaysGame = data.games.find(game => datesAreOnSameDay(new Date(game.firstOpened), GameDate));
     const completedToday = data.games.find(game => datesAreOnSameDay(new Date(game.firstOpened), GameDate) && game.completed) != null;
 


### PR DESCRIPTION
- change link shown when shared from zodziuks.lt to github page
- fix some warnings (unused promise from `writeText` and `parseFloat` expects a string)
- fix statistics bug: `currentStreak` and `longestStreak` shouldn't go back to 0 when an unsolved game is found. `longestStreak` was finding the first streak